### PR TITLE
specifying layout template

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -19,6 +19,7 @@ collections: # A list of collections the CMS should be able to edit
     create: true # Allow users to create new documents in this collection
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     fields: # The fields each document in this collection have
+      - {label: "Layout", name: "layout", widget: "hidden", default: "post"}
       - {label: "Title", name: "title", widget: "string", tagname: "h1"}
       - {label: "Body", name: "body", widget: "markdown"}
       - {label: "Categories", name: "categories", widget: "string"}


### PR DESCRIPTION
Posts should have layout templates defined. Otherwise posts are rendered without structure and style.
