### PR TITLE
Updated Gemfile with jekyll version 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "jekyll"
+gem "jekyll", "~> 3.1"


### PR DESCRIPTION
The default dependency resolved to an outdated jekyll version (2.x) on Ubuntu 14.04 which led to an error when running the local server on port 4000
